### PR TITLE
update docs to reflect scTenifoldXct integration in index

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -10,6 +10,29 @@ and predictable.
 - [Workflow Classes](api/workflows.md): step-wise
   ``scTenifoldNet`` and ``scTenifoldKnk`` classes.
 
+## scTenifoldXct Re-exports
+
+When the ``[xct]`` extra is installed, the following names are importable
+directly from ``scTenifold``:
+
+| Name | Description |
+|---|---|
+| ``scTenifoldXct`` | Main class for single-sample cell-cell interaction analysis |
+| ``merge_scTenifoldXct`` | Class for two-sample differential interaction analysis |
+| ``set_seed`` | Set random seeds for reproducibility |
+| ``get_Xct_pairs`` | Retrieve significant ligand-receptor pairs |
+| ``plot_XNet`` | Plot the interaction network |
+
+```python
+from scTenifold import scTenifoldXct, merge_scTenifoldXct
+```
+
+These are lazy re-exports of the standalone ``scTenifoldXct`` package —
+they return the exact same objects. Accessing them without the extra raises
+an actionable ``ImportError``. See [scTenifoldXct](xct.md) for usage and
+the full API reference in the
+[scTenifoldXct repository](https://github.com/cailab-tamu/scTenifoldXct).
+
 ## Lower-Level Functions
 
 - [Network Functions](api/networks.md): PC network construction,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -83,6 +83,50 @@ model = scTenifoldNet.load("./saved_net")
 print(model.d_regulation.head())
 ```
 
+## scTenifoldXct Commands
+
+These subcommands require the ``[xct]`` extra
+(``pip install "scTenifoldpy[xct]"``). They are thin passthroughs to the
+standalone `scTenifoldXct` package; the same commands are also available
+as `sctenifoldxct` if that package is installed directly.
+
+### Single-sample interaction analysis
+
+```bash
+scTenifold xct data.h5ad \
+    --sender cell_A \
+    --receiver cell_B \
+    --label ident \
+    --workdir ./xct_results \
+    --output xct_enriched
+```
+
+| Option | Short | Default | Description |
+|---|---|---|---|
+| ``--sender`` | ``-s`` | ``cell_A`` | Sender cell type label |
+| ``--receiver`` | ``-r`` | ``cell_B`` | Receiver cell type label |
+| ``--label`` | ``-l`` | ``ident`` | ``.obs`` column holding cell-type labels |
+| ``--workdir`` | ``-w`` | ``xct_results`` | Output directory for GRN files |
+| ``--output`` | ``-o`` | ``xct_enriched`` | Output file stem |
+| ``--n_cpus`` | | ``-1`` | CPUs for GRN construction (``-1`` = all) |
+| ``--rebuild/--no-rebuild`` | | rebuild | Rebuild gene regulatory networks |
+| ``--verbose`` | ``-v`` | false | Verbose output |
+
+### Two-sample differential interaction analysis
+
+```bash
+scTenifold xct-merge data.h5ad condition WT KO \
+    --sender cell_A \
+    --receiver cell_B \
+    --label ident
+```
+
+Positional arguments: `file`, `cond_label` (the `.obs` column distinguishing
+conditions), `cond_wt` (reference label), `cond_ko` (comparison label). All
+``--sender`` / ``--receiver`` / ``--label`` / ``--workdir`` / ``--output`` /
+``--n_cpus`` / ``--rebuild`` flags are the same as `xct` above (output
+defaults to ``xct_enriched_diff``).
+
 ## Data Path Conventions
 
 - A directory at ``x_data_path`` is treated as a 10x folder

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # scTenifoldpy
 
 ``scTenifoldpy`` is a Python port of the scTenifold family of
-single-cell gene-regulatory-network analyses. It provides two workflows:
+single-cell gene-regulatory-network analyses. It provides three workflows:
 
 - **scTenifoldNet**: compare two single-cell expression matrices and rank
   genes by differential regulation. Use it when you have a control and a
@@ -9,8 +9,11 @@ single-cell gene-regulatory-network analyses. It provides two workflows:
 - **scTenifoldKnk**: build a wild-type network and simulate a virtual
   knockout of one or more genes. Use it when you only have one sample and
   want to predict downstream effects of perturbing a gene.
+- **scTenifoldXct**: predict cell-cell interactions between a sender and a
+  receiver cell type using per-cell-type GRNs and neural-network manifold
+  alignment. Available via the optional ``[xct]`` extra.
 
-Both workflows share the same backbone: per-cell QC, many PC networks on
+Net and Knk share the same backbone: per-cell QC, many PC networks on
 resampled cells, tensor decomposition, manifold alignment, and a
 differential regulation test. See [Pipeline Steps](pipeline-steps.md)
 for the step-by-step inputs and outputs.
@@ -57,6 +60,7 @@ The returned DataFrame has one row per shared gene with columns
 - [Quickstart](quickstart.md): end-to-end runnable examples.
 - [Tutorials](source/1_data.ipynb): notebook examples for data,
   scTenifoldNet, virtual knockout, and visualization.
+- [scTenifoldXct](xct.md): cell-cell interaction analysis (optional extra).
 - [Parallel Backends](parallel-backends.md): scale across cores or a Ray
   cluster.
 - [AnnData Input](anndata.md): pass AnnData objects instead of
@@ -67,5 +71,5 @@ The returned DataFrame has one row per shared gene with columns
 
 ## Version
 
-This documentation reflects ``0.2.x``. See the
+This documentation reflects ``0.3.x``. See the
 [Changelog](changelog.md) for what changed since ``0.1``.


### PR DESCRIPTION
- index.md: add Xct as third workflow, link to xct.md, bump version to 0.3.x
- cli.md: document xct and xct-merge subcommands with option tables
- api-reference.md: add scTenifoldXct re-exports section with symbol table