### PR TITLE
Release 0.4.0: local web UI

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,79 @@
 # Changelog
 
+## 0.4.0
+
+### Web UI
+
+- **New optional local web UI** for running the scTenifold suite without
+  writing code. `sctenifold-ui` starts a FastAPI server and opens a
+  single-page app in the browser; everything runs locally and no data
+  leaves the machine. Ships as the new `[ui]` extra.
+- Three workflows selectable in the UI:
+  - **Compare networks** (scTenifoldNet) — rank genes by differential
+    regulation between two conditions.
+  - **Virtual knockout** (scTenifoldKnk) — rank genes by the predicted
+    impact of knocking out one or more genes.
+  - **Build GRN only** — infer a single gene regulatory network from one
+    sample (`sc_QC` → `cal_pcNet`), with no comparison or knockout. No
+    resampling, so the parallel-backend options don't apply and are
+    hidden.
+- Provide data three ways: a small **synthetic example**, the real **10x
+  PBMC3k** dataset (the Seurat/Scanpy tutorial data, QC-filtered,
+  downsampled, and cached on first use), or **upload your own** as a
+  genes-by-cells CSV or an AnnData `.h5ad` file.
+- Results render as a ranked gene table (Net/Knk) or edge list (GRN),
+  capped to the top rows on screen and downloadable in full as CSV.
+- Jobs run one at a time on a background worker; a run keeps going and is
+  repainted correctly when you switch workflow tabs mid-run.
+
+### Packaging
+
+- New optional extra `ui = ["fastapi>=0.110", "uvicorn>=0.29",
+  "python-multipart>=0.0.9", "anndata>=0.10"]`. The base install stays
+  lightweight and web-framework-free.
+- New `sctenifold-ui` console entry point.
+- Regenerated `uv.lock` for the `ui` extra and the `httpx` test
+  dependency.
+
+### CLI
+
+- New `sctenifold-ui` command (also runnable as
+  `python -m scTenifold.webapp`) with `--host`, `--port`, and
+  `--no-browser`. Defaults to `127.0.0.1:8001` to avoid the common 8000
+  clash.
+
+### Bug Fixes
+
+- Report a clear, actionable error when a knockout gene was removed by QC
+  before the knockout step, distinguishing genes dropped by QC from genes
+  never present in the input — previously surfaced as an opaque pandas
+  `KeyError`.
+- Reject `n_jobs=0` (rejected by joblib) up front, validated both
+  client-side and in the request schema.
+
+### Robustness
+
+- Uploads are streamed to disk a chunk at a time with a size cap, instead
+  of buffering whole files in memory; oversized requests are rejected on
+  their declared `Content-Length` before the body is read.
+- Dataset fetches use `GITHUB_TOKEN`/`GH_TOKEN` when available and cache
+  the repository tree per process, avoiding GitHub's 60-requests/hour
+  unauthenticated API rate limit (notably in CI).
+
+### Tests
+
+- New suites: `test_webapp_api`, `test_webapp_jobs`, `test_webapp_cli`,
+  `test_webapp_pbmc3k`, and `test_knk_ko_gene_validation`. The web UI
+  suites auto-skip without the `[ui]` extra, so the default matrix stays
+  green.
+- New CI `test-ui` job runs the web UI suites on Python 3.9 and 3.14.
+
+### Docs
+
+- New **Local Web UI** page covering install, launch, the three
+  workflows, dataset options, and results; added a UI screenshot and
+  promoted the section in the README.
+
 ## 0.3.0
 
 ### API

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scTenifoldpy"
-version = "0.3.0"
+version = "0.4.0"
 description = "Python implementation of scTenifoldNet and scTenifoldKnk workflows, with optional scTenifoldXct cell-cell interaction support."
 readme = "README.md"
 requires-python = ">=3.9,<3.15"


### PR DESCRIPTION
Add the 0.4.0 changelog entry and bump the package version from 0.3.0. 0.4.0 introduces the optional local web UI ([ui] extra, sctenifold-ui entry point) for running scTenifoldNet/Knk and a new GRN-only workflow without code, plus the supporting bug fixes, upload/rate-limit robustness work, web UI test suites, and docs.